### PR TITLE
Update OpenSSL to the latest stable version (3.3.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-14
             arch: arm64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
           - os: ubuntu-latest
             arch: aarch64

--- a/scripts/build-openssl.bat
+++ b/scripts/build-openssl.bat
@@ -21,7 +21,7 @@ call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Buil
 SET PATH=%PATH%;C:\Program Files\NASM
 
 mkdir openssl
-curl -L https://www.openssl.org/source/openssl-3.2.1.tar.gz -o openssl.tar.gz
+curl -L https://www.openssl.org/source/openssl-3.3.0.tar.gz -o openssl.tar.gz
 tar xzf openssl.tar.gz -C openssl --strip-components 1
 cd openssl
 

--- a/scripts/build-openssl.py
+++ b/scripts/build-openssl.py
@@ -25,10 +25,6 @@ def get_platform():
     if system == "Linux":
         return f"manylinux_{machine}"
     elif system == "Darwin":
-        # cibuildwheel sets ARCHFLAGS:
-        # https://github.com/pypa/cibuildwheel/blob/5255155bc57eb6224354356df648dc42e31a0028/cibuildwheel/macos.py#L207-L220
-        if "ARCHFLAGS" in os.environ:
-            machine = os.environ["ARCHFLAGS"].split()[1]
         return f"macosx_{machine}"
     elif system == "Windows":
         if struct.calcsize("P") * 8 == 64:
@@ -69,8 +65,6 @@ output_dir = os.path.abspath("output")
 if platform.system() == "Linux" and os.environ.get("CIBUILDWHEEL") == "1":
     output_dir = "/output"
     run(["yum", "-y", "install", "perl-IPC-Cmd"])
-elif platform.system() == "Darwin" and os.environ.get("ARCHFLAGS") == "-arch arm64":
-    configure_args = ["darwin64-arm64"]
 output_tarball = os.path.join(output_dir, f"openssl-{get_platform()}.tar.gz")
 
 for d in [build_dir, output_dir, source_dir]:
@@ -80,7 +74,7 @@ if not os.path.exists(output_tarball):
     os.chdir(build_dir)
 
     # build openssl
-    extract("openssl", "https://www.openssl.org/source/openssl-3.2.1.tar.gz")
+    extract("openssl", "https://www.openssl.org/source/openssl-3.3.0.tar.gz")
     os.chdir("openssl")
     run(["./config"] + configure_args + ["no-apps", "no-comp", "no-dso", "no-shared", "no-tests"])
     run(["make"])


### PR DESCRIPTION
We use different macOs versions for arm64 / x86_64 builds.